### PR TITLE
Automatically set the stats client when class implements `StatsClientAwareInterface`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.2",
-        "cosmastech/statsd-client-adapter": "dev-stats-aware-interface",
+        "cosmastech/statsd-client-adapter": "^0.3",
         "illuminate/support": "^10.0|^11.0",
         "illuminate/contracts": "^10.0|^11.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^8.2",
-        "cosmastech/statsd-client-adapter": "^0.2.0",
+        "cosmastech/statsd-client-adapter": "dev-stats-aware-interface",
         "illuminate/support": "^10.0|^11.0",
         "illuminate/contracts": "^10.0|^11.0"
     },
@@ -45,7 +45,8 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Cosmastech\\LaravelStatsDAdapter\\StatsDAdapterServiceProvider"
+                "Cosmastech\\LaravelStatsDAdapter\\StatsDAdapterServiceProvider",
+                "Cosmastech\\LaravelStatsDAdapter\\StatsClientAwareServiceProvider"
             ],
             "aliases": {
                 "Stats": "Cosmastech\\LaravelStatsDAdapter\\Stats"

--- a/src/StatsClientAwareServiceProvider.php
+++ b/src/StatsClientAwareServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Cosmastech\LaravelStatsDAdapter;
+
+use Cosmastech\StatsDClientAdapter\Adapters\Contracts\StatsClientAwareInterface;
+use Cosmastech\StatsDClientAdapter\Adapters\StatsDClientAdapter;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
+
+class StatsClientAwareServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        //
+    }
+
+    public function boot(): void
+    {
+        $this->app->afterResolving(
+            StatsClientAwareInterface::class,
+            function (StatsClientAwareInterface $wantsStatsClient, Application $application): void {
+                $wantsStatsClient->setStatsClient($application->make(StatsDClientAdapter::class));
+            }
+        );
+    }
+}

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -3,6 +3,7 @@
 namespace Cosmastech\LaravelStatsDAdapter\Tests;
 
 use Cosmastech\LaravelStatsDAdapter\AdapterManager;
+use Cosmastech\LaravelStatsDAdapter\StatsClientAwareServiceProvider;
 use Illuminate\Config\Repository;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
@@ -10,6 +11,13 @@ use Orchestra\Testbench\TestCase;
 class AbstractTestCase extends TestCase
 {
     use WithWorkbench;
+
+    protected $enablesPackageDiscoveries = true;
+
+    protected function getPackageProviders($app)
+    {
+        return [StatsClientAwareServiceProvider::class];
+    }
 
     protected function getEnvironmentSetUp($app)
     {

--- a/tests/Fixtures/WantsStatsClient.php
+++ b/tests/Fixtures/WantsStatsClient.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Cosmastech\LaravelStatsDAdapter\Tests\Fixtures;
+
+use Cosmastech\StatsDClientAdapter\Adapters\Concerns\StatsClientAwareTrait;
+use Cosmastech\StatsDClientAdapter\Adapters\Contracts\StatsClientAwareInterface;
+use Cosmastech\StatsDClientAdapter\Adapters\StatsDClientAdapter;
+
+class WantsStatsClient implements StatsClientAwareInterface
+{
+    use StatsClientAwareTrait;
+
+    public function getStatsClient(): StatsDClientAdapter
+    {
+        return $this->statsClient;
+    }
+}

--- a/tests/StatsClientAwareServiceProviderTest.php
+++ b/tests/StatsClientAwareServiceProviderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Cosmastech\LaravelStatsDAdapter\Tests;
+
+use Cosmastech\LaravelStatsDAdapter\Tests\Fixtures\WantsStatsClient;
+use Cosmastech\StatsDClientAdapter\Adapters\StatsDClientAdapter;
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
+
+class StatsClientAwareServiceProviderTest extends AbstractTestCase
+{
+    #[Test]
+    public function appResolvesStatsClientAwareInterfaceClass_classHasStatsClientSet(): void
+    {
+        // Given
+        Config::set("statsd-adapter.default", "memory");
+
+        // When
+        $wantsStatsClient = $this->app->make(WantsStatsClient::class);
+
+        // Then
+        self::assertSame(
+            $this->app->make(StatsDClientAdapter::class),
+            $wantsStatsClient->getStatsClient()
+        );
+    }
+}


### PR DESCRIPTION
Do not merge until upstream change is released.