### PR TITLE
default to no origin detection for log_datadog

### DIFF
--- a/config/statsd-adapter.php
+++ b/config/statsd-adapter.php
@@ -9,7 +9,7 @@ return [
     "default_tags" => [],
 
     /**
-     * You may name your channel anything you wish. Valid drivers are:
+     * You may name your channel anything you wish. Valid adapters are:
      *      memory
      *      league
      *      datadog
@@ -49,6 +49,7 @@ return [
             "global_tags" => [],
             "metric_prefix" => null,
             "disable_telemetry" => null,
+            "origin_detection" => false,
         ],
     ],
 ];

--- a/src/AdapterManager.php
+++ b/src/AdapterManager.php
@@ -159,7 +159,7 @@ class AdapterManager extends MultipleInstanceManager
     protected function createDatadogAdapter(array $config): DatadogStatsDClientAdapter
     {
         return new DatadogStatsDClientAdapter(
-            new DogStatsd($config), // @phpstan-ignore
+            new DogStatsd($config), // @phpstan-ignore argument.type
             $this->getDefaultTags(),
             clock: $this->getClockImplementation()
         );

--- a/src/AdapterManager.php
+++ b/src/AdapterManager.php
@@ -159,7 +159,7 @@ class AdapterManager extends MultipleInstanceManager
     protected function createDatadogAdapter(array $config): DatadogStatsDClientAdapter
     {
         return new DatadogStatsDClientAdapter(
-            new DogStatsd($config),
+            new DogStatsd($config), // @phpstan-ignore
             $this->getDefaultTags(),
             clock: $this->getClockImplementation()
         );


### PR DESCRIPTION
Noticed I was getting a warning when using log_datadog with the newer versions of dogstats.