### PR TITLE
fix facade lint for laravel 13 support

### DIFF
--- a/src/Stats.php
+++ b/src/Stats.php
@@ -3,7 +3,6 @@
 namespace Cosmastech\LaravelStatsDAdapter;
 
 use Illuminate\Support\Facades\Facade;
-use UnitEnum;
 
 /**
  * @method static \Cosmastech\StatsDClientAdapter\Adapters\StatsDClientAdapter channel(string|null $name = null)
@@ -17,15 +16,15 @@ use UnitEnum;
  * @method static void purge(string|null $name = null)
  * @method static \Cosmastech\LaravelStatsDAdapter\AdapterManager extend(string $name, \Closure $callback)
  * @method static \Cosmastech\LaravelStatsDAdapter\AdapterManager setApplication(\Illuminate\Contracts\Foundation\Application $app)
- * @method static void timing(string|UnitEnum $stat, float $durationMs, float $sampleRate = 1, array $tags = [])
- * @method static mixed time(callable $closure, string|UnitEnum $stat, float $sampleRate = 1, array $tags = [])
- * @method static void gauge(string|UnitEnum $stat, float $value, float $sampleRate = 1, array $tags = [])
- * @method static void histogram(string|UnitEnum $stat, float $value, float $sampleRate = 1, array $tags = [])
- * @method static void distribution(string|UnitEnum $stat, float $value, float $sampleRate = 1, array $tags = [])
- * @method static void set(string|UnitEnum $stat, float|string $value, float $sampleRate = 1, array $tags = [])
- * @method static void increment(string|UnitEnum|array $stats, float $sampleRate = 1, array $tags = [], int $value = 1)
- * @method static void decrement(string|UnitEnum|array $stats, float $sampleRate = 1, array $tags = [], int $value = 1)
- * @method static void updateStats(string|UnitEnum|array $stats, int $delta = 1, float $sampleRate = 1, array $tags = [])
+ * @method static void timing(string|\UnitEnum $stat, float $durationMs, float $sampleRate = 1, array $tags = [])
+ * @method static mixed time(callable $closure, string|\UnitEnum $stat, float $sampleRate = 1, array $tags = [])
+ * @method static void gauge(string|\UnitEnum $stat, float $value, float $sampleRate = 1, array $tags = [])
+ * @method static void histogram(string|\UnitEnum $stat, float $value, float $sampleRate = 1, array $tags = [])
+ * @method static void distribution(string|\UnitEnum $stat, float $value, float $sampleRate = 1, array $tags = [])
+ * @method static void set(string|\UnitEnum $stat, float|string $value, float $sampleRate = 1, array $tags = [])
+ * @method static void increment(string|\UnitEnum|array $stats, float $sampleRate = 1, array $tags = [], int $value = 1)
+ * @method static void decrement(string|\UnitEnum|array $stats, float $sampleRate = 1, array $tags = [], int $value = 1)
+ * @method static void updateStats(string|\UnitEnum|array $stats, int $delta = 1, float $sampleRate = 1, array $tags = [])
  * @method static mixed getClient()
  *
  * @see \Cosmastech\LaravelStatsDAdapter\AdapterManager


### PR DESCRIPTION
Replaced `string|UnitEnum` with `string|\UnitEnum` in the nine affected `@method` annotations, and removed the now-unused use `UnitEnum;` import.